### PR TITLE
Fix font height up with line paddings

### DIFF
--- a/imesupportplugin.py
+++ b/imesupportplugin.py
@@ -213,6 +213,8 @@ class WindowLayout(object):
 
         font_face = view.settings().get('font_face', '')
         font_height = int(view.line_height())
+        font_height -= (view.settings().get("line_padding_top", 0)
+            + view.settings().get("line_padding_bottom", 0))
 
         if self.get_setting('imesupport_debug'):
             sublime.status_message('IMESupport: ' + str(p) + repr(offset))


### PR DESCRIPTION
view.line_height()がline_padding_top(bottom)の設定値を含むため、差し引いて正しいフォントサイズで表示されるようにしました。
取り込みのご検討をお願いいたします。
