### PR TITLE
Add sublime_text version selectors

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -6,6 +6,7 @@
             "details": "https://github.com/chikatoike/IMESupport",
             "releases": [
                 {
+                    "sublime_text": "*",
                     "platforms": "windows",
                     "details": "https://github.com/chikatoike/IMESupport"
                 }


### PR DESCRIPTION
We require these now due to the confusion it caused in the past
