### PR TITLE
suppress input mode popup after initial change

### DIFF
--- a/imesupportplugin.py
+++ b/imesupportplugin.py
@@ -159,9 +159,9 @@ def set_inline_position(hwnd, x, y, font_face, font_height):
     # borrowed from http://d.hatena.ne.jp/doloopwhile/20090627/1275176169
     hIMC = windll.imm32.ImmGetContext(hwnd)
     status = windll.imm32.ImmGetOpenStatus(hIMC)
-    if not status:
+    # if not status:
         # Enable IME temporary.
-        ctypes.windll.imm32.ImmSetOpenStatus(hIMC, 1)
+        # ctypes.windll.imm32.ImmSetOpenStatus(hIMC, 1)
 
     pt = POINT(x, y)
     cf = COMPOSITIONFORM()


### PR DESCRIPTION
In the direct input mode of Google Japanese input, the input mode popup keeps showing up whenever the cursor moves, which is not the typical Japanese IME behavior. This change seems to suppress it without breaking other stuff as far as I can see.
グーグル日本語入力でダイレクインプットモードになっている場合、入力モードを示す[あ]と[A]のポップアップが常に表示されてしまいます。ひらがな入力の場合は大丈夫です。EmEditorなどでは入力モードの切替時やIMEの切替時のみに一度表示されます。一時的にIMEをオンにする部分をコメントアウトしたことで変なことが起こるかもしれないと思ったのですが、私の環境では特に副作用なく動いているようです。

問題のスクリーンショットをこっちに載せました。http://python.blog.shinobi.jp/sublime/sublime_with_googlejapaneseinput
