### PR TITLE
Fix TypeError: Don't know how to convert parameter 4

### DIFF
--- a/imesupport/globalhook.py
+++ b/imesupport/globalhook.py
@@ -68,7 +68,7 @@ def test():
     assert setup(platform.machine() == 'AMD64')
     hwnd = ctypes.windll.user32.FindWindowW(TEST_CLASSNAME, 0)
     assert hwnd != 0
-    set_inline_position(hwnd, x, y, 'font', font_height)
+    set_inline_position(hwnd, x, y, 'font', int(font_height))
 
 
 def window_process():


### PR DESCRIPTION
Windows 10 64bit, SublimeText3 3103
Python 3.4.3

いつからのアップデートからかこのエラーでIMESupportを読みこまなくなっていたので修正。 
別個入れているPythonのせいかもしれない
